### PR TITLE
API for Artist list with Test

### DIFF
--- a/apps/artist/serializers.py
+++ b/apps/artist/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from apps.artist.models import Artist
+
+
+class ArtistSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Artist
+        fields = ('nickname',)

--- a/apps/artist/tests.py
+++ b/apps/artist/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 
+from rest_framework.test import APITestCase
+
 from apps.artist.models import Artist
 
 
@@ -9,3 +11,13 @@ class ArtistModelTests(TestCase):
         nickname = 'Nirvana'
         artist = Artist.objects.create(nickname=nickname)
         self.assertEqual(str(artist), nickname)
+
+
+class ArtistAPITests(APITestCase):
+
+    def test_API_에서_생성된_Artist_객체를_받아오는지_확인(self):
+        nickname = 'Oasis'
+        self.artist = Artist.objects.create(nickname=nickname)
+
+        response = self.client.get("/artists/", {}, format='json')
+        self.assertIn({'nickname': nickname}, response.data, msg=response.data)

--- a/apps/artist/views.py
+++ b/apps/artist/views.py
@@ -1,3 +1,12 @@
-from django.shortcuts import render
+from rest_framework import viewsets
+from rest_framework.permissions import AllowAny
 
-# Create your views here.
+from apps.artist.models import Artist
+from apps.artist.serializers import ArtistSerializer
+
+
+class ArtistViewSet(viewsets.ModelViewSet):
+    permission_classes = (AllowAny,)
+
+    queryset = Artist.objects.all()
+    serializer_class = ArtistSerializer

--- a/threethousandwon/urls.py
+++ b/threethousandwon/urls.py
@@ -20,10 +20,12 @@ from rest_framework import routers
 from rest_framework_jwt.views import obtain_jwt_token
 
 from apps.authentication.views import UserViewSet
+from apps.artist.views import ArtistViewSet
 
 # Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
 router.register(r'users', UserViewSet)
+router.register(r'artists', ArtistViewSet)
 
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.


### PR DESCRIPTION
1. Serializer, ViewSet 생성 및 urls에 규칙 추가
(/artists/에서 nickname 필드를 포함하는 Artist 목록을 반환함)

2. 인증되지 않은 사용자도 Artist API에 접근 가능하도록
ViewSet의 권한 수정

* 지난 번에 View에 개별 권한 설정이 실패했던 것은,
apps에 __init__이 없었던 것과 관련 있는 것으로 추정됨.
지금은 문제 없이 적용 완료.